### PR TITLE
fix: allow baseURL to be empty string

### DIFF
--- a/addon/services/new-version.js
+++ b/addon/services/new-version.js
@@ -74,7 +74,7 @@ export default class NewVersionService extends Service {
   get url() {
     const versionFileName = this._newVersionConfig.versionFileName;
     const baseUrl =
-      this._config.prepend || this._config.rootURL || this._config.baseURL;
+      this._config.prepend || this._config.rootURL || this._config.baseURL || '';
     return baseUrl + versionFileName;
   }
 


### PR DESCRIPTION
### Summary

When we deliberately want `.baseUrl` to be an empty string we get undefined instead, which becomes a URL request like so: `https://instrumentl.staging.i9l.net/undefinedapi/v1/frontend-version?_=1777312066122`.

### Proposed solution

Allow `.baseUrl` to be an empty string by falling back to `''`.
