### PR TITLE
fix: /projects/api/v1/frontend-version => //api/v1/frontend-version

### DIFF
--- a/addon/services/new-version.js
+++ b/addon/services/new-version.js
@@ -74,7 +74,7 @@ export default class NewVersionService extends Service {
   get url() {
     const versionFileName = this._newVersionConfig.versionFileName;
     const baseUrl =
-      this._config.prepend || this._config.rootURL || this._config.baseURL || '';
+      this._config.prepend || this._config.rootURL || this._config.baseURL || '/';
     return baseUrl + versionFileName;
   }
 


### PR DESCRIPTION
The version endpoint is being incorrectly routed as a relative path